### PR TITLE
Use signin from konnector-libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "build"
   ],
   "dependencies": {
-    "cozy-konnector-connection": "carrieje/cozy-konnector-connection",
     "cozy-konnector-libs": "3.8.1",
     "pdfjs": "2.0.0-alpha.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1883,10 +1883,6 @@ cozy-jobs-cli@1.0.8:
     opn "^5.1.0"
     regenerator-runtime "^0.11.1"
 
-cozy-konnector-connection@carrieje/cozy-konnector-connection:
-  version "0.0.0"
-  resolved "https://codeload.github.com/carrieje/cozy-konnector-connection/tar.gz/05f55089766e0202fd637e0ceb33369b6a45f126"
-
 cozy-konnector-libs@3.8.1, cozy-konnector-libs@^3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/cozy-konnector-libs/-/cozy-konnector-libs-3.8.1.tgz#c4f9d6c2df742023897691c8d0e257a516ec00cd"


### PR DESCRIPTION
Replace the old `carrieje/cozy-konnector-connection` by the new `signin` method from `cozy-konnector-libs`.