### PR TITLE
fix: properly handle pdf files and remove image temporarily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ yarn-error.log
 # connector data files
 .account
 .token.json
-konnector-dev-config.json
+konnector-dev-config.json*
 
 # Build
 build/

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/cheerio": "0.22.7",
     "@types/moment": "2.13.0",
     "copy-webpack-plugin": "4.5.1",
-    "cozy-jobs-cli": "1.0.9",
+    "cozy-jobs-cli": "1.0.12",
     "eslint": "4.19.1",
     "eslint-config-cozy-app": "0.5.1",
     "git-directory-deploy": "1.5.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,8 @@ function start(fields: any): Promise<any> {
     .then((bills: Array<any>) => {
       return saveBills(bills, fields.folderPath, {
         timeout: Date.now() + 60 * 1000,
-        identifiers: "theoldreader" // bank operation identifier
+        identifiers: "theoldreader", // bank operation identifier
+        contentType: 'application/pdf'
       });
     });
 }
@@ -99,8 +100,8 @@ function getPdfStream(bill: any): Promise<any> {
         billData[2].firstChild.nodeValue.trim()
       );
     })
-    .then((pdfStream: fs.ReadStream) => {
-      bill.filestream = pdfStream;
+    .then((pdfStream) => {
+      bill.filestream = pdfStream._doc;
       delete bill.fileurl;
       return bill;
     })
@@ -135,12 +136,12 @@ function generatePDF(invoidID: string, account: string, item: string, date: stri
     require("pdfjs/font/Helvetica-Bold.json")
   );
 
-  const src: Buffer = fs.readFileSync("tor-logo.jpg");
-  const logo: any = new pdf.Image(src);
+  // const src: Buffer = fs.readFileSync("tor-logo.jpg");
+  // const logo: any = new pdf.Image(src);
 
   var doc: any = new pdf.Document({ font: helveticaFont });
 
-  doc.cell({ paddingBottom: 0.5 * pdf.cm }).image(logo, { width: 150 });
+  // doc.cell({ paddingBottom: 0.5 * pdf.cm }).image(logo, { width: 150 });
   doc
     .cell({ paddingBottom: 0.5 * pdf.cm })
     .text()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1920,22 +1920,22 @@ cozy-client-js@^0.8.0:
     pouchdb-adapter-cordova-sqlite "https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
     pouchdb-find "0.10.4"
 
-cozy-jobs-cli@1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/cozy-jobs-cli/-/cozy-jobs-cli-1.0.9.tgz#ed6b618f3344bb635f2fcf08e68c81af28f2416e"
+cozy-jobs-cli@1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/cozy-jobs-cli/-/cozy-jobs-cli-1.0.12.tgz#8fab7442c0ea86a00638504b593ed11ba9fb78e5"
   dependencies:
     btoa "^1.1.2"
     cheerio "^1.0.0-rc.2"
     commander "^2.12.2"
     core-js "^2.5.3"
     cozy-client-js "^0.8.0"
-    cozy-konnector-libs "^4.0.0"
-    cozy-logger "^1.0.4"
+    cozy-konnector-libs "^4.1.2"
+    cozy-logger "^1.1.0"
     isomorphic-fetch "^2.2.1"
     opn "^5.1.0"
     regenerator-runtime "^0.11.1"
 
-cozy-konnector-libs@4.1.2:
+cozy-konnector-libs@4.1.2, cozy-konnector-libs@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/cozy-konnector-libs/-/cozy-konnector-libs-4.1.2.tgz#f681cd9834321fe2ce6ba7dd56fd45cd96478d83"
   dependencies:
@@ -1966,41 +1966,6 @@ cozy-konnector-libs@4.1.2:
     request-debug "^0.2.0"
     request-promise "^4.2.1"
     uuid "^3.1.0"
-
-cozy-konnector-libs@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-konnector-libs/-/cozy-konnector-libs-4.0.0.tgz#a2c15a8c3eee2d8fba491fce1d9aba31fcbc1e8c"
-  dependencies:
-    babel-cli "^6.26.0"
-    babel-plugin-transform-object-rest-spread "^6.26.0"
-    babel-preset-env "^1.6.0"
-    bluebird "^3.5.0"
-    bluebird-retry "^0.11.0"
-    btoa "^1.1.2"
-    chalk "^2.3.2"
-    cheerio "^1.0.0-rc.2"
-    commander "^2.12.2"
-    core-js "^2.4.1"
-    cozy-client-js "^0.8.0"
-    cozy-logger "^1.0.4"
-    date-fns "^1.29.0"
-    isomorphic-fetch "^2.2.1"
-    jest "^22.0.0"
-    jsdoc-to-markdown "^4.0.1"
-    lodash "^4.17.4"
-    moment "^2.18.1"
-    opn "^5.1.0"
-    raven "^2.4.0"
-    regenerator-runtime "^0.11.0"
-    replay "^2.1.2"
-    request "^2.81.0"
-    request-debug "^0.2.0"
-    request-promise "^4.2.1"
-    uuid "^3.1.0"
-
-cozy-logger@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/cozy-logger/-/cozy-logger-1.0.4.tgz#598a826ef0824e590bf68a667b83b2d7c7d2cfbe"
 
 cozy-logger@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
I had to remove the image from the pdf since it does not work yet. fs.readFileSync does not work when the connector is built with webpack.

Maybe we could fetch it from theoldreader website directly with a request.

An I had to add contentType property or else the files would be recognized as octet-stream by the drive application and would not be possible to show.

